### PR TITLE
deps: bump jsonrpsee from 0.25.1 to 0.26.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -13,7 +13,7 @@ bitcoin = { version = "0.32.2", features = ["serde"] }
 hashlink = { version = "0.10.0", features = ["serde_impl"] }
 hex = { version = "0.4.3", features = ["serde"] }
 http = "1.1.0"
-jsonrpsee = { version = "0.25.1", features = ["client", "macros"] }
+jsonrpsee = { version = "0.26.0", features = ["client", "macros"] }
 monostate = "0.1.13"
 serde = { version = "1.0.183", features = ["alloc", "derive"] }
 serde_json = "1.0.104"

--- a/rust-toolchain.toml
+++ b/rust-toolchain.toml
@@ -1,2 +1,2 @@
 [toolchain]
-channel = "1.85.0"
+channel = "1.88.0"


### PR DESCRIPTION
Also bumps the rust-toolchain channel from 1.85.0 to 1.88.0, which is required transitively by jsonrpsee 0.26's proc-macro deps)