### PR TITLE
Allow getmininginfo without next target

### DIFF
--- a/src/client.rs
+++ b/src/client.rs
@@ -117,7 +117,7 @@ pub struct MiningInfo {
     #[serde(with = "bitcoin::network::as_core_arg")]
     pub chain: bitcoin::Network,
     pub signet_challenge: Option<bitcoin::ScriptBuf>,
-    pub next: MiningInfoNext,
+    pub next: Option<MiningInfoNext>,
 }
 
 #[derive(Clone, Copy, Debug, Deserialize)]


### PR DESCRIPTION
## Summary\n- Make getmininginfo.next optional in the JSON-RPC client model\n- Keeps compatibility with patched Bitcoin Core builds that omit the next mining target object\n\n## Test\n- cargo check